### PR TITLE
[update] FOODS[order1] -> FOODS[order2]に変更

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 DRINKS = [
   { name: 'コーヒー', price: '300' },
   { name: 'カフェラテ', price: '400' },
@@ -15,11 +14,11 @@ FOODS = [
 ].freeze
 
 def take_order(menus)
-  menus.each.with_index(1) do |menu, i|
-    puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
+  menus.each.with_index(0) do |menu, i|
+    puts "(#{i+1})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
@@ -29,6 +28,5 @@ order1 = take_order(DRINKS)
 
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
-
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = FOODS[order2][:price].to_i + DRINKS[order1][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
# プラクティス：コードの修正
## 問題点
- [ ] 頼んだつもりのメニューが選択できない。
- [ ] 最後の番号のメニューを選択するとエラーとなる。 
- [ ] お会計額が異様に高い。
- [ ] 違う番号のドリンク、フードを注文したとき、お会計が正しくない。

## 変更点
- [ ] total計算時の`order1`と`order2`を入れ替え。
- [ ] ループ開始時の添字開始を0に変更
- [ ] `order_number`の数値を−１にする

レビューお願いします。